### PR TITLE
Mobile support

### DIFF
--- a/Tool/LocalScript/FastToolDrop.lua
+++ b/Tool/LocalScript/FastToolDrop.lua
@@ -38,16 +38,20 @@ tool.Equipped:Connect(function()
 		-- “If the player pressed the Backspace key, and the game didn’t already use that input for something else,
 		-- then run the code inside.”
 		if not gameProcessed and input.KeyCode == Enum.KeyCode.Backspace then
+			if screenGui then -- If the GUI is already present if mobile detected but using keyboard, destroy it
+				screenGui:Destroy()
+			end
 			dropTool()
 		end
 	end)
 	
 	-- Mobile support: add a screen button if on touch
 	if UserInputService.TouchEnabled and not mobileButton then
+		print("Tool equippd")
 		local player = game.Players.LocalPlayer
 		local playerGui = player:WaitForChild("PlayerGui")
 
-		local screenGui = Instance.new("ScreenGui")
+		screenGui = Instance.new("ScreenGui")
 		screenGui.Name = "DropToolGui"
 		screenGui.ResetOnSpawn = false
 		screenGui.Parent = playerGui
@@ -62,12 +66,18 @@ tool.Equipped:Connect(function()
 		mobileButton.Parent = screenGui
 
 		mobileButton.MouseButton1Click:Connect(function()
+			if screenGui then
+				screenGui:Destroy()
+				end
 			dropTool()
 		end)
 	end
 end)
 
 tool.Unequipped:Connect(function()
+	if screenGui then
+		screenGui:Destroy()
+		end
 	if connection then
 		connection:Disconnect()
 		connection = nil

--- a/Tool/LocalScript/FastToolDrop.lua
+++ b/Tool/LocalScript/FastToolDrop.lua
@@ -6,25 +6,37 @@ local DropToolRequest = ReplicatedStorage.DropToolRequest
 local connection
 local hasFired = false
 
+local function dropTool()
+	if hasFired then return end
+	hasFired = true
+	local character = tool.Parent
+	local rightHand
+	local rightGrip
+
+	-- Check for R15 first (RightHand exists)
+	if character:FindFirstChild("RightHand") then
+		rightHand = character.RightHand
+		rightGrip = rightHand.RightGrip
+	else
+		-- Fallback to R6 (Right Arm)
+		rightHand = character["Right Arm"]
+		rightGrip = rightHand.RightGrip
+	end
+	--print("Tool dropped")
+	if rightGrip then
+		DropToolRequest:FireServer(tool, rightGrip)
+	end
+end
 
 tool.Equipped:Connect(function()
+		
+		-- Storing the connection lets you disconnect it later (e.g., when the tool is unequipped)
+		-- Keyboard (PC) support
 	connection = UserInputService.InputBegan:Connect(function(input, gameProcessed)
+		-- “If the player pressed the Backspace key, and the game didn’t already use that input for something else,
+		-- then run the code inside.”
 		if not gameProcessed and input.KeyCode == Enum.KeyCode.Backspace then
-			local character = tool.Parent
-			local rightHand
-			local rightGrip
-
-			-- Check for R15 first (RightHand exists)
-			if character:FindFirstChild("RightHand") then
-				rightHand = character.RightHand
-				rightGrip = rightHand.RightGrip
-			else
-				-- Fallback to R6 (Right Arm)
-				rightHand = character["Right Arm"]
-				rightGrip = rightHand.RightGrip
-			end
-			--print("Tool dropped")
-			DropToolRequest:FireServer(tool, rightGrip)
+			dropTool()
 		end
 	end)
 end)

--- a/Tool/LocalScript/FastToolDrop.lua
+++ b/Tool/LocalScript/FastToolDrop.lua
@@ -64,12 +64,26 @@ tool.Equipped:Connect(function()
 		mobileButton.BackgroundColor3 = Color3.new(0.2, 0.2, 0.2)
 		mobileButton.TextColor3 = Color3.new(1, 1, 1)
 		mobileButton.Parent = screenGui
+		
+		-- 🔵 Add rounded corners
+		local uiCorner = Instance.new("UICorner")
+		uiCorner.CornerRadius = UDim.new(0, 12) -- adjust as desired
+		uiCorner.Parent = mobileButton
+
+		local tapCount = 0
 
 		mobileButton.MouseButton1Click:Connect(function()
-			if screenGui then
-				screenGui:Destroy()
+			tapCount += 1
+
+			if tapCount >= 3 then
+				if screenGui then
+					screenGui:Destroy()
 				end
-			dropTool()
+				dropTool()
+				tapCount = 0 -- reset for next time
+			else
+				mobileButton.Text = "Tap " .. (3 - tapCount) .. " more"
+			end
 		end)
 	end
 end)

--- a/Tool/LocalScript/FastToolDrop.lua
+++ b/Tool/LocalScript/FastToolDrop.lua
@@ -28,6 +28,8 @@ local function dropTool()
 	end
 end
 
+local mobileButton
+
 tool.Equipped:Connect(function()
 		
 		-- Storing the connection lets you disconnect it later (e.g., when the tool is unequipped)
@@ -39,6 +41,30 @@ tool.Equipped:Connect(function()
 			dropTool()
 		end
 	end)
+	
+	-- Mobile support: add a screen button if on touch
+	if UserInputService.TouchEnabled and not mobileButton then
+		local player = game.Players.LocalPlayer
+		local playerGui = player:WaitForChild("PlayerGui")
+
+		local screenGui = Instance.new("ScreenGui")
+		screenGui.Name = "DropToolGui"
+		screenGui.ResetOnSpawn = false
+		screenGui.Parent = playerGui
+
+		mobileButton = Instance.new("TextButton")
+		mobileButton.Size = UDim2.new(0, 50, 0, 50)
+		mobileButton.Position = UDim2.new(1, -200, 1, -60) -- bottom right
+		mobileButton.AnchorPoint = Vector2.new(0, 0)
+		mobileButton.Text = "Drop Tool"
+		mobileButton.BackgroundColor3 = Color3.new(0.2, 0.2, 0.2)
+		mobileButton.TextColor3 = Color3.new(1, 1, 1)
+		mobileButton.Parent = screenGui
+
+		mobileButton.MouseButton1Click:Connect(function()
+			dropTool()
+		end)
+	end
 end)
 
 tool.Unequipped:Connect(function()


### PR DESCRIPTION
1. Refactored drop code into function. 
2. Added code for when mobile is detected to display a 'drop tool' button in the player's GUI.
3. drop tool GUI button now disappears when tool unequipped or button pressed.
4. Added click counter to GUI button, must click thrice to activate drop. 
5. Added GUI button corner rounding.